### PR TITLE
Update to Latest Version of .NET (RWD.Toolbox.Ui.Middleware)

### DIFF
--- a/.github/workflows/NuGetPush.yml
+++ b/.github/workflows/NuGetPush.yml
@@ -16,7 +16,7 @@ jobs:
 
     env:
       BUILD_CONFIG: 'Release'
-      DOTNET_VERSION: '6.0.401' # The .NET SDK version to use   
+      DOTNET_VERSION: '10.0.x' # The .NET SDK version to use   
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/docfx.yml
+++ b/.github/workflows/docfx.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ master ]
 env:
-  DOTNET_VERSION: '6.0.401' # The .NET SDK version to use
+  DOTNET_VERSION: '10.0.x' # The .NET SDK version to use
 jobs:
   generate-docs:
     runs-on: windows-latest

--- a/RWD.Toolbox.Ui.Middleware.CspHeader/RWD.Toolbox.Ui.Middleware.CspHeader.csproj
+++ b/RWD.Toolbox.Ui.Middleware.CspHeader/RWD.Toolbox.Ui.Middleware.CspHeader.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Description>A Free .NET Library to assist with writing a HTML Content Security Policy Header.</Description>
     <Copyright>RealWorldDevelopers 2023</Copyright>
@@ -42,9 +42,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor" Version="2.3.0" />
     <PackageReference Include="System.Threading.Tasks" Version="4.3.0" />
   </ItemGroup>
 

--- a/RWD.Toolbox.Ui.Middleware.Demo/RWD.Toolbox.Ui.Middleware.Demo.csproj
+++ b/RWD.Toolbox.Ui.Middleware.Demo/RWD.Toolbox.Ui.Middleware.Demo.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <PackageLicenseFile>eula.md</PackageLicenseFile>

--- a/RWD.Toolbox.Ui.Middleware.PermissionsPolicy/RWD.Toolbox.Ui.Middleware.PermissionsPolicy.csproj
+++ b/RWD.Toolbox.Ui.Middleware.PermissionsPolicy/RWD.Toolbox.Ui.Middleware.PermissionsPolicy.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
   </ItemGroup>
 
 </Project>

--- a/RWD.Toolbox.Ui.Middleware.SecurityHeaders/RWD.Toolbox.Ui.Middleware.SecurityHeaders.csproj
+++ b/RWD.Toolbox.Ui.Middleware.SecurityHeaders/RWD.Toolbox.Ui.Middleware.SecurityHeaders.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RepositoryUrl>https://github.com/RealWorldDevelopers/RWD.Toolbox.Ui.Middleware</RepositoryUrl>
     <PackageLicenseFile>eula.md</PackageLicenseFile>
     <Description>A Free .NET Library to assist with writing a HTML Security Headers.</Description>
@@ -42,7 +42,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
RWD.Toolbox.Ui.Middleware Should Now Target .NET 10 (Referring to: #16) 

- The following `.csproj` files should now be targeting .NET 10:
   - `RWD.Toolbox.Ui.Middleware.CspHeader.csproj`
   - `RWD.Toolbox.Ui.Middleware.Demo.csproj`
   - `RWD.Toolbox.Ui.Middleware.PermissionsPolicy.csproj`
   - `RWD.Toolbox.Ui.Middleware.SecurityHeaders.csproj`  
- As a result, the following packages became deprecated and have had their versions updated to `2.3.0`:
   - `Microsoft.AspNetCore.Http.Abstractions`
   - `Microsoft.AspNetCore.Mvc.ViewFeatures`
   - `Microsoft.AspNetCore.Razor`
- Updated the following GitHub Actions configurations to target .NET 10:
   - Push to NuGet.org (`NuGetPush.yml`) 
   - DoxFx Build and Publish (`docfx.yml`)